### PR TITLE
Update gtest on .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gtest"]
 	path = gtest
-	url = https://gitlab.doc.ic.ac.uk/jpassera/google-test-mirror.git
+	url = https://chromium.googlesource.com/external/googletest.git


### PR DESCRIPTION
gtest sub module points to a private git repository, you need an user and password for it.
This one (https://chromium.googlesource.com/external/googletest.git) is a public one and it compiles well with it